### PR TITLE
Add missing Stream overrides

### DIFF
--- a/src/DotUtils.StreamUtils/StreamExtensions.cs
+++ b/src/DotUtils.StreamUtils/StreamExtensions.cs
@@ -98,29 +98,28 @@ public static class StreamExtensions
 
     public static byte[] ReadToEnd(this Stream stream)
     {
-        if (stream.TryGetLength(out long length))
-        {
-            BinaryReader reader = new(stream);
-            return reader.ReadBytes((int)length);
-        }
-
-        using var ms = new MemoryStream();
+        MemoryStream ms = stream.TryGetLength(out long length) && length <= int.MaxValue ? new((int)length) : new();
         stream.CopyTo(ms);
-        return ms.ToArray();
+        byte[] buffer = ms.GetBuffer();
+        return buffer.Length == ms.Length ? buffer : ms.ToArray();
     }
 
     public static bool TryGetLength(this Stream stream, out long length)
     {
         try
         {
-            length = stream.Length;
-            return true;
+            if (stream.CanSeek)
+            {
+                length = stream.Length;
+                return true;
+            }
         }
         catch (NotSupportedException)
         {
-            length = 0;
-            return false;
         }
+
+        length = 0;
+        return false;
     }
 
     public static Stream ToReadableSeekableStream(this Stream stream)

--- a/src/DotUtils.StreamUtils/SubStream.cs
+++ b/src/DotUtils.StreamUtils/SubStream.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotUtils.StreamUtils;
 
@@ -36,7 +38,8 @@ public class SubStream : Stream
 
     public override long Position { get => _position; set => throw new NotImplementedException(); }
 
-    public override void Flush() { }
+    public override void Flush() => _stream.Flush();
+    public override Task FlushAsync(CancellationToken cancellationToken) => _stream.FlushAsync(cancellationToken);
     public override int Read(byte[] buffer, int offset, int count)
     {
         count = Math.Min((int)Math.Max(Length - _position, 0), count);
@@ -44,6 +47,43 @@ public class SubStream : Stream
         _position += read;
         return read;
     }
+    public override int ReadByte()
+    {
+        if (Length - _position > 0)
+        {
+            int value = _stream.ReadByte();
+            if (value >= 0)
+            {
+                _position++;
+                return value;
+            }
+        }
+
+        return -1;
+    }
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        count = Math.Min((int)Math.Max(Length - _position, 0), count);
+        int read = await _stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        _position += read;
+        return read;
+    }
+#if NET
+    public override int Read(Span<byte> buffer)
+    {
+        buffer = buffer.Slice(0, Math.Min((int)Math.Max(Length - _position, 0), buffer.Length));
+        int read = _stream.Read(buffer);
+        _position += read;
+        return read;
+    }
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        buffer = buffer.Slice(0, Math.Min((int)Math.Max(Length - _position, 0), buffer.Length));
+        int read = await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        _position += read;
+        return read;
+    }
+#endif
     public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
     public override void SetLength(long value) => throw new NotImplementedException();
     public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();


### PR DESCRIPTION
It's important for perf to override the base implementations, in particular for Read/WriteByte.

I just copied the existing implementations to the new overrides and fixed up the implementations with as minimal changes as possible. I also tried to retain the style of the surrounding code.

And none of the existing implementations have tests, so I didn't add any for these, as much as it pained me :)